### PR TITLE
Fix image names from rackerlabs->carinamarina

### DIFF
--- a/hello-world-app/README.md
+++ b/hello-world-app/README.md
@@ -3,10 +3,10 @@
 This is a sample Python web application, running on port 5000,
 which prints `Hello  World!`.
 
-1. Run the `rackerlabs/hello-world-app` container.
+1. Run the `carinamarina/hello-world-app` container.
 
     ```bash
-    docker run --detach --name app --publish-all rackerlabs/hello-world-app
+    docker run --detach --name app --publish-all carinamarina/hello-world-app
     ```
 
 2. Identity the port where the app container was published. In the example below,

--- a/hello-world-app/build
+++ b/hello-world-app/build
@@ -2,4 +2,4 @@ set +v
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-docker build --tag rackerlabs/hello-world-app $DIR
+docker build --tag carinamarina/hello-world-app $DIR

--- a/hello-world-web/README.md
+++ b/hello-world-web/README.md
@@ -1,19 +1,19 @@
 # Hello World Web
 
 This is a sample Python web application, running on port 5000,
-which prints data retrieved from the linked `rackerlabs/hello-world-app` container.
+which prints data retrieved from the linked `carinamarina/hello-world-app` container.
 
-1. Run the `rackerlabs/hello-world-app` container.
+1. Run the `carinamarina/hello-world-app` container.
 
     ```bash
-    docker run --detach --name app rackerlabs/hello-world-app
+    docker run --detach --name app carinamarina/hello-world-app
     ```
 
-2. Run the `rackerlabs/hello-world-web` container, linking to the app container using
+2. Run the `carinamarina/hello-world-web` container, linking to the app container using
     the alias **helloapp**.
 
     ```bash
-    docker run --detach --name web --link app:helloapp --publish-all rackerlabs/hello-world-web
+    docker run --detach --name web --link app:helloapp --publish-all carinamarina/hello-world-web
     ```
 
 3. Identity the port where the web container was published. In the example below,

--- a/hello-world-web/build
+++ b/hello-world-web/build
@@ -2,4 +2,4 @@ set +v
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-docker build --tag rackerlabs/hello-world-web $DIR
+docker build --tag carinamarina/hello-world-web $DIR

--- a/try-rails/README.md
+++ b/try-rails/README.md
@@ -6,7 +6,7 @@ MySQL database hosted on the Rackspace Cloud Database service.
 1. Create a MySQL database in the IAD region in the Rackspace Cloud Control Panel.
     Note the host name, and credentials as it will be needed in the next step.
 
-2. Run the `rackerlabs/try-rails` container. Update the `DATABASE_URL` environment
+2. Run the `carinamarina/try-rails` container. Update the `DATABASE_URL` environment
     variable with your database connection details.
 
     ```bash
@@ -14,7 +14,7 @@ MySQL database hosted on the Rackspace Cloud Database service.
     --env DATABASE_URL="mysql://username:password@host/dbname" \
     --detach \
     --publish-all \
-    rackerlabs/try-rails
+    carinamarina/try-rails
     ```
 
 3. Identity the port where the rails application was published. In the example below,


### PR DESCRIPTION
I have a few repos (hello-world and try-rails) which were still using the old name.